### PR TITLE
#19: fixed toolbar width and alignment 

### DIFF
--- a/sass/components/_homepage.scss
+++ b/sass/components/_homepage.scss
@@ -27,11 +27,9 @@
 
     .sticky-toolbar {
       position: fixed;
-      width: calc(100vw - 21.5%);
       background: #fff;
       z-index: 3;
       top: 4.5rem;
-      left: 16.5rem;
       height: 100px;
       box-sizing: border-box;
       margin-right: 20px;
@@ -70,6 +68,27 @@
   }
 }
 
+@media (min-width: 1441px) and (max-width: 2560px) {
+  .sticky-toolbar {
+    left: 27.5rem;
+    width: calc(100vw - 19%);
+  }
+}
+
+@media (min-width: 1441px) and (max-width: 1920px) {
+  .sticky-toolbar {
+    left: 21rem;
+    width: calc(100vw - 20%);
+  }
+}
+
+@media (min-width: 1025px) and (max-width: 1440px) {
+  .sticky-toolbar {
+    left: 16.5rem;
+    width: calc(100vw - 21.5%);
+  }
+}
+
 @media (min-width: 769px) and (max-width: 1024px) {
   .homepage {
     h1 {
@@ -79,6 +98,7 @@
       .sticky-toolbar {
         top: 4.45rem;
         left: 12.5rem;
+        width: calc(100vw - 21.5%);
       }
     }
   }


### PR DESCRIPTION
This PR fixes #19 which involves handling the screen size based alignment of the sticky toolbar.
![Screen Shot 2021-01-02 at 5 52 44 PM](https://user-images.githubusercontent.com/21155917/103457248-73631700-4d23-11eb-8e07-4255d28aa6d2.png)
