### PR TITLE
Default URL redirect fix(#22)

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,16 @@
+import { useEffect } from 'react'
+import Router from 'next/router'
 import Layout from '../components/Layout'
 import Category from './category/[slug]'
 
 const Home = () => {
+  useEffect(() => {
+    const { pathname } = Router
+    if (pathname == '/') {
+      Router.push('/category/new-in')
+    }
+  })
+
   return <Layout>{/* <Category /> */}</Layout>
 }
 


### PR DESCRIPTION
## Issue resolved:
#22 Default URL doesn't redirect to category page.
## Solution:
Redirect to the URL on the page loads using hooks as category page uses slug from URL.
## Code sample:
```
  useEffect(() => {
    const { pathname } = Router
    if (pathname == '/') {
      Router.push('/category/new-in')
    }
  })
```